### PR TITLE
Adding Relaxed Secutiry Flag and updating report portal cucumber version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.epam.reportportal</groupId>
             <artifactId>agent-java-cucumber</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.epam.reportportal</groupId>

--- a/src/main/java/com/appium/manager/LocalAppiumManager.java
+++ b/src/main/java/com/appium/manager/LocalAppiumManager.java
@@ -9,6 +9,7 @@ import com.thoughtworks.device.SimulatorManager;
 import com.thoughtworks.iOS.IOSManager;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
+import io.appium.java_client.service.local.flags.GeneralServerFlag;
 
 import java.io.File;
 import java.io.IOException;
@@ -67,6 +68,7 @@ public class LocalAppiumManager implements IAppiumManager {
                                         + FileLocations.APPIUM_LOGS_DIRECTORY
                                         + "appium_logs.txt"))
                         .withIPAddress(host)
+                        .withArgument(GeneralServerFlag.RELAXED_SECURITY)
                         .usingAnyFreePort();
         appiumDriverLocalService = builder.build();
         appiumDriverLocalService.start();


### PR DESCRIPTION
Adding _GeneralServerFlag.RELAXED_SECURITY is mandatory on many occasions of ADB shell interactions and there is no harm by relaxing it by default.