### PR TITLE
#419 Fixing null pointer exception when Remote ATD jar is not started in Remote Host

### DIFF
--- a/src/main/java/com/appium/manager/RemoteAppiumManager.java
+++ b/src/main/java/com/appium/manager/RemoteAppiumManager.java
@@ -132,7 +132,7 @@ public class RemoteAppiumManager extends Helpers implements IAppiumManager {
             figlet("Unable to connect to Remote Host " + machineIP);
             e.printStackTrace();
         } catch (NullPointerException e){
-            figlet("Unable to connect remote the devices" + machineIP);
+            figlet("Unable to connect remote devices" + machineIP);
             e.printStackTrace();
         } catch (Exception e){
             e.printStackTrace();
@@ -158,7 +158,7 @@ public class RemoteAppiumManager extends Helpers implements IAppiumManager {
             figlet("Unable to connect to Remote Host " + machineIP);
             e.printStackTrace();
         } catch (NullPointerException e){
-            figlet("Unable to connect remote the devices" + machineIP);
+            figlet("Unable to connect remote devices" + machineIP);
             e.printStackTrace();
         } catch (Exception e){
             e.printStackTrace();


### PR DESCRIPTION
Added Remote getDevices & getSimulator inside catch block to avoid NullPointer and ConnectException.