### PR TITLE
tune HeadSpin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Add the below dependencies in your pom.xml (Master)
 
 ## [Customize Tests](https://github.com/saikrishna321/AppiumTestDistribution/wiki/Customize-Tests)
 
+## [Configure-tests-for-HeadSpin](caps/headspin_capabilities.json)
+
+No changes required. `Platform='android' CONFIG_FILE='./configs/headspin_config.properties' mvn clean -Dtest=Runner test`
+
 ## [Tips](https://github.com/saikrishna321/AppiumTestDistribution/wiki/Tips)
 
 ## Video log Prerequisites

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ Add the below dependencies in your pom.xml (Master)
 
 ## [Configure-tests-for-HeadSpin](caps/headspin_capabilities.json)
 
-No changes required. `Platform='android' CONFIG_FILE='./configs/headspin_config.properties' mvn clean -Dtest=Runner test`
-
 ## [Tips](https://github.com/saikrishna321/AppiumTestDistribution/wiki/Tips)
 
 ## Video log Prerequisites

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ Add the below dependencies in your pom.xml (Master)
 
 ## [Configure-tests-for-GenyMotionCloud](https://github.com/AppiumTestDistribution/AppiumTestDistribution/wiki/Configure-test-for-Genymotion-cloud)
 
-## [Customize Tests](https://github.com/saikrishna321/AppiumTestDistribution/wiki/Customize-Tests)
-
 ## [Configure-tests-for-HeadSpin](caps/headspin_capabilities.json)
+
+## [Customize Tests](https://github.com/saikrishna321/AppiumTestDistribution/wiki/Customize-Tests)
 
 ## [Tips](https://github.com/saikrishna321/AppiumTestDistribution/wiki/Tips)
 

--- a/caps/headspin_capabilities.json
+++ b/caps/headspin_capabilities.json
@@ -1,0 +1,33 @@
+{
+  "android": {
+    "automationName": "UiAutomator2",
+    "newCommandTimeout": 600,
+    "platformName": "Android",
+    "headspin:capture": false,
+    "app": {
+      "local": "https://github.com/shridharkalagi/AppiumSample/raw/master/VodQA.apk"
+    },
+  },
+  "iOS": {
+    "platformName": "iOS",
+    "automationName": "XCUITest",
+    "bundleId": "com.apple.Preferences"
+  },
+  "cloud": {
+    "android": [
+      {
+        "udid": "ZY223P3W32"
+      },
+      {
+        "udid": "os_version:>=10"
+      }
+    ]
+  },
+  "hostMachines": [
+    {
+      "isCloud": true,
+      "machineIP": "appium-dev.headspin.io:443/v0/<api token>",
+      "cloudName": "headspin"
+    }
+  ]
+}

--- a/configs/headspin_config.properties
+++ b/configs/headspin_config.properties
@@ -1,5 +1,4 @@
 RUNNER=distribute
-FRAMEWORK=cucumber
+FRAMEWORK=testng
 RUNNER_LEVEL=methods
 CAPS=./caps/headspin_capabilities.json
-CLOUD_KEY=headspin_key

--- a/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
+++ b/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
@@ -71,17 +71,26 @@ public class DesiredCapabilityBuilder extends ArtifactsUploader {
             capabilityObject(desiredCapabilities, platFormCapabilities, key);
         });
         AppiumDevice deviceProperty = AppiumDeviceManager.getAppiumDevice();
-        desiredCapabilities.setCapability("device",
-            deviceProperty.getDevice().getName());
-        desiredCapabilities.setCapability(MobileCapabilityType.DEVICE_NAME,
-            deviceProperty.getDevice().getName());
+
+        String deviceName = deviceProperty.getDevice().getName();
+        if (!deviceName.equals("null")) {
+            desiredCapabilities.setCapability("device", deviceName);
+            desiredCapabilities.setCapability(MobileCapabilityType.DEVICE_NAME, deviceName);
+        }
+
+        String udid = deviceProperty.getDevice().getUdid();
+        if (!udid.equals("null")) {
+            desiredCapabilities.setCapability(MobileCapabilityType.UDID, udid);
+        }
+
         Object pCloudyApiKey = desiredCapabilities.getCapability("pCloudy_ApiKey");
         if (null == pCloudyApiKey) {
             desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, "");
-            desiredCapabilities.setCapability(CapabilityType.VERSION,
-                    deviceProperty.getDevice().getOsVersion());
-            desiredCapabilities.setCapability(MobileCapabilityType.PLATFORM_VERSION,
-                    deviceProperty.getDevice().getOsVersion());
+            String osVersion = deviceProperty.getDevice().getOsVersion();
+            if (!osVersion.equals("null")) {
+                desiredCapabilities.setCapability(CapabilityType.VERSION, osVersion);
+                desiredCapabilities.setCapability(MobileCapabilityType.PLATFORM_VERSION, osVersion);
+            }
         }
         LOGGER.info("desiredCapabilityForCloud: " + desiredCapabilities);
         desiredCapabilitiesThreadLocal.set(desiredCapabilities);

--- a/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
+++ b/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
@@ -73,13 +73,13 @@ public class DesiredCapabilityBuilder extends ArtifactsUploader {
         AppiumDevice deviceProperty = AppiumDeviceManager.getAppiumDevice();
 
         String deviceName = deviceProperty.getDevice().getName();
-        if (!deviceName.equals("null")) {
+        if (deviceName != null) {
             desiredCapabilities.setCapability("device", deviceName);
             desiredCapabilities.setCapability(MobileCapabilityType.DEVICE_NAME, deviceName);
         }
 
         String udid = deviceProperty.getDevice().getUdid();
-        if (!udid.equals("null")) {
+        if (udid != null) {
             desiredCapabilities.setCapability(MobileCapabilityType.UDID, udid);
         }
 
@@ -87,7 +87,8 @@ public class DesiredCapabilityBuilder extends ArtifactsUploader {
         if (null == pCloudyApiKey) {
             desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, "");
             String osVersion = deviceProperty.getDevice().getOsVersion();
-            if (!osVersion.equals("null")) {
+
+            if (osVersion != null) {
                 desiredCapabilities.setCapability(CapabilityType.VERSION, osVersion);
                 desiredCapabilities.setCapability(MobileCapabilityType.PLATFORM_VERSION, osVersion);
             }

--- a/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
+++ b/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
@@ -86,8 +86,8 @@ public class DesiredCapabilityBuilder extends ArtifactsUploader {
         Object pCloudyApiKey = desiredCapabilities.getCapability("pCloudy_ApiKey");
         if (null == pCloudyApiKey) {
             desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, "");
-            String osVersion = deviceProperty.getDevice().getOsVersion();
 
+            String osVersion = deviceProperty.getDevice().getOsVersion();
             if (osVersion != null) {
                 desiredCapabilities.setCapability(CapabilityType.VERSION, osVersion);
                 desiredCapabilities.setCapability(MobileCapabilityType.PLATFORM_VERSION, osVersion);

--- a/src/main/java/com/appium/device/HostMachineDeviceManager.java
+++ b/src/main/java/com/appium/device/HostMachineDeviceManager.java
@@ -208,19 +208,16 @@ public class HostMachineDeviceManager {
                                 Device d = new Device();
                                 d.setOs(devicePlatform);
 
-                                String osVersion = String.valueOf(((Map) o).get("osVersion"));
-                                if (osVersion != null) {
-                                    d.setOsVersion(osVersion);
+                                if (((Map) o).get("osVersion") != null) {
+                                    d.setOsVersion(String.valueOf(((Map) o).get("osVersion")));
                                 }
 
-                                String deviceName = String.valueOf(((Map) o).get("deviceName"));
-                                if (deviceName != null) {
-                                    d.setName(deviceName);
+                                if (((Map) o).get("deviceName") != null) {
+                                    d.setName(String.valueOf(((Map) o).get("deviceName")));
                                 }
 
-                                String udid = String.valueOf(((Map) o).get("udid"));
-                                if (udid != null) {
-                                    d.setUdid(udid);
+                                if (((Map) o).get("udid") != null) {
+                                    d.setUdid(String.valueOf(((Map) o).get("udid")));
                                 }
 
                                 d.setCloud(true);

--- a/src/main/java/com/appium/device/HostMachineDeviceManager.java
+++ b/src/main/java/com/appium/device/HostMachineDeviceManager.java
@@ -191,13 +191,38 @@ public class HostMachineDeviceManager {
                     JSONObject cloud = capabilities.getCapabilityObjectFromKey("cloud");
 
                     String cloudName = capabilities.getCloudName(ip).toLowerCase();
-                    if (cloudName.equalsIgnoreCase("pCloudy")
-                            || cloudName.equalsIgnoreCase("headspin")) {
+                    if (cloudName.equalsIgnoreCase("pCloudy")) {
                         cloud.toMap().forEach((devicePlatform, devices) -> {
                             ((List) devices).forEach(o -> {
                                 Device d = new Device();
                                 d.setOs(devicePlatform);
                                 d.setOsVersion(((Map) o).get("osVersion").toString());
+                                d.setCloud(true);
+                                LOGGER.info("Device: " + d);
+                                cloudDevices.add(d);
+                            });
+                        });
+                    } else if (cloudName.equalsIgnoreCase("headspin")) {
+                        cloud.toMap().forEach((devicePlatform, devices) -> {
+                            ((List) devices).forEach(o -> {
+                                Device d = new Device();
+                                d.setOs(devicePlatform);
+
+                                String osVersion = String.valueOf(((Map) o).get("osVersion"));
+                                if (osVersion != null) {
+                                    d.setOsVersion(osVersion);
+                                }
+
+                                String deviceName = String.valueOf(((Map) o).get("deviceName"));
+                                if (deviceName != null) {
+                                    d.setName(deviceName);
+                                }
+
+                                String udid = String.valueOf(((Map) o).get("udid"));
+                                if (udid != null) {
+                                    d.setUdid(udid);
+                                }
+
                                 d.setCloud(true);
                                 LOGGER.info("Device: " + d);
                                 cloudDevices.add(d);


### PR DESCRIPTION
Thanks for adding HeadSpin support in https://github.com/AppiumTestDistribution/AppiumTestDistribution/pull/855
This PR has a few tuning for it.

1. HeadSpin allows using `udid` mainly since our platform expect real devices
2. Added caps/headspin_capabilities.json as an example

I tested `Platform='android' CONFIG_FILE='./configs/headspin_config.properties' mvn clean -Dtest=Runner test` this with proper our api token