### PR TITLE
Unable to create chrome session for headspin execution

### DIFF
--- a/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
+++ b/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
@@ -91,7 +91,7 @@ public class DesiredCapabilityBuilder extends ArtifactsUploader {
             if (desiredCapabilities.getCapability(CapabilityType.BROWSER_NAME) == null ) {
                 desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, "");
             } else {
-                 desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME,
+                desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME,
                          desiredCapabilities.getCapability(CapabilityType.BROWSER_NAME));
             }
             String osVersion = deviceProperty.getDevice().getOsVersion();

--- a/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
+++ b/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
@@ -90,6 +90,8 @@ public class DesiredCapabilityBuilder extends ArtifactsUploader {
         if (null == pCloudyApiKey) {
             if(desiredCapabilities.getCapability(CapabilityType.BROWSER_NAME) == null ){
                 desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, "");
+            }else{
+                 desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, desiredCapabilities.getCapability(CapabilityType.BROWSER_NAME));
             }
          
             String osVersion = deviceProperty.getDevice().getOsVersion();

--- a/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
+++ b/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
@@ -88,8 +88,10 @@ public class DesiredCapabilityBuilder extends ArtifactsUploader {
 
         Object pCloudyApiKey = desiredCapabilities.getCapability("pCloudy_ApiKey");
         if (null == pCloudyApiKey) {
-            desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, "");
-
+            if(desiredCapabilities.getCapability(CapabilityType.BROWSER_NAME) == null ){
+                desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, "");
+            }
+         
             String osVersion = deviceProperty.getDevice().getOsVersion();
             if (osVersion != null) {
                 desiredCapabilities.setCapability(CapabilityType.VERSION, osVersion);

--- a/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
+++ b/src/main/java/com/appium/capabilities/DesiredCapabilityBuilder.java
@@ -88,12 +88,12 @@ public class DesiredCapabilityBuilder extends ArtifactsUploader {
 
         Object pCloudyApiKey = desiredCapabilities.getCapability("pCloudy_ApiKey");
         if (null == pCloudyApiKey) {
-            if(desiredCapabilities.getCapability(CapabilityType.BROWSER_NAME) == null ){
+            if (desiredCapabilities.getCapability(CapabilityType.BROWSER_NAME) == null ) {
                 desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, "");
-            }else{
-                 desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, desiredCapabilities.getCapability(CapabilityType.BROWSER_NAME));
+            } else {
+                 desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME,
+                         desiredCapabilities.getCapability(CapabilityType.BROWSER_NAME));
             }
-         
             String osVersion = deviceProperty.getDevice().getOsVersion();
             if (osVersion != null) {
                 desiredCapabilities.setCapability(CapabilityType.VERSION, osVersion);


### PR DESCRIPTION
There was an issue in ATD, due to which headspin chrome session was not getting created, the browserName was explicitly added as null