### PR TITLE
Device free issue

### DIFF
--- a/src/main/java/com/appium/manager/AppiumParallelMethodTestListener.java
+++ b/src/main/java/com/appium/manager/AppiumParallelMethodTestListener.java
@@ -159,8 +159,8 @@ public final class AppiumParallelMethodTestListener extends Helpers
                     }
                 }
                 if (iInvokedMethod.isTestMethod()) {
-                    AppiumDriverManager.getDriver().quit();
                     deviceAllocationManager.freeDevice();
+                    AppiumDriverManager.getDriver().quit();
                     if (!isCloudExecution()) {
                         appiumDriverManager.stopAppiumDriver();
                     }


### PR DESCRIPTION
We have observe that if there is issue in       AppiumDriverManager.getDriver().quit();  deviceAllocationManager.freeDevice(); never called.